### PR TITLE
Implement how to join page and CSS updates

### DIFF
--- a/src/join.html
+++ b/src/join.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Join - UCP Clubs</title>
+    <link rel="stylesheet" href="../styles/styles.css">
+</head>
+<body>
+    
+    <header class="navbar">
+        <div class="logo">UCP Student Clubs</div>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="clubs.html">Club Categories</a></li>
+                <li><a href="events.html">Upcoming Events</a></li>
+                <li><a href="join.html">How to Join</a></li>
+                <li><a href="highlights.html">Achievements</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main class="hero-section" style="text-align: left;">
+        <h1 style="text-align: center;">How to Join a Student Club</h1>
+        <p style="text-align: center;">Ready to dive in? Follow these simple steps to become an official club member!</p>
+
+        <section class="importance-section">
+            <h2>Step-by-Step Registration</h2>
+            <ol style="margin-left: 20px; margin-top: 10px;">
+                <li><strong>Explore:</strong> Browse the 'Club Categories' page to find a club that matches your interests.</li>
+                <li><strong>Register:</strong> Fill out the online membership form available on the university student portal.</li>
+                <li><strong>Attend Orientation:</strong> Join the introductory session during the first week of the semester to meet the executive body.</li>
+            </ol>
+        </section>
+
+        <section class="importance-section">
+            <h2>Meeting Schedules & Guidelines</h2>
+            <ul style="margin-left: 20px; margin-top: 10px;">
+                <li><strong>Schedules:</strong> Most clubs meet bi-weekly on Wednesdays or Fridays between 3:00 PM and 5:00 PM.</li>
+                <li><strong>Commitment:</strong> Active members are expected to attend at least 70% of general body meetings.</li>
+                <li><strong>Code of Conduct:</strong> All members must adhere to the university's values of respect, inclusivity, and collaboration.</li>
+            </ul>
+        </section>
+
+        <div class="cta-buttons">
+            <a href="clubs.html" class="btn primary-btn">Find Your Club Now</a>
+        </div>
+    </main>
+
+    <footer>
+        <p>&copy; 2026 University Student Clubs Portal. Built collaboratively using Git.</p>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a new page, `join.html`, which provides students with clear instructions on how to join university clubs. The page includes step-by-step registration guidance, meeting schedules, participation expectations, and a call-to-action to explore club categories.

New informational page:

* Added `join.html` with detailed instructions on how to join a student club, including registration steps, meeting schedules, and guidelines for participation.
* Incorporated navigation links and consistent styling to match the rest of the site.